### PR TITLE
Explicitly set mime type for template

### DIFF
--- a/src/inertia/middleware.clj
+++ b/src/inertia/middleware.clj
@@ -51,5 +51,6 @@
                                     :headers {"x-inertia" "true"
                                               "vary" "accept"}
                                     :body data-page}
-                    :else (rr/response (template (json/write-value-as-string data-page)))))
+                    :else (-> (rr/response (template (json/write-value-as-string data-page)))
+                            (rr/content-type "text/html"))))
             response)))))))


### PR DESCRIPTION
Did this to fix an issue running behind AWS APIGW, it'll put application/json on if the content-type not set explicitly